### PR TITLE
Release v1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "generate-swap-project",
   "description": "Generate An ES.Next/StandardJS/UnitTest Ready, Github or Gitlab Project in Seconds! − A generator for SWAP projects −",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "homepage": "https://github.com/sirap-group/generate-swap-project",
   "author": "Rémi Becheras (https://github.com/rbecheras)",
   "repository": "sirap-group/generate-swap-project",


### PR DESCRIPTION
Fix #127

Just patch-bumped package.json to `1.4.1` to test publishing a new patch release and test it.

It worked fine.

So I merge that branch and I'll build and publish a new patch release from the `master` branch (`v1.4.2`)